### PR TITLE
Change readIntLE to readUIntLE in convertBinaryToInteger

### DIFF
--- a/src/headerFunctions.js
+++ b/src/headerFunctions.js
@@ -53,7 +53,7 @@ function parseFieldSubRecord(buffer, encoding) {
 }
 
 function convertBinaryToInteger(buffer) {
-  return buffer.readIntLE(0, buffer.length);
+  return buffer.readUIntLE(0, buffer.length);
 }
 
 function decodeType(byte) {


### PR DESCRIPTION
This fixes wrong length assumptions and therefore field reading in some dbf files. For me it fixed a bug where single-byte char field following a long char field was read as a part of that field and you could see that the length reported for the long field was negative.
I don't know what effect this will have on displacement, but since it's not used anywhere in the code, I believe it will be beneficial for length and decimalPlaces, since those can't be negative anyway.